### PR TITLE
Introduce TObjectDictionary

### DIFF
--- a/Source/Collections.Dictionary.pas
+++ b/Source/Collections.Dictionary.pas
@@ -8,7 +8,6 @@ uses
 type
   TPair<T, U> = public KeyValuePair<T, U>;
   TDictionary<TKey,TValue> = public class(TEnumerable<TPair<TKey,TValue>>)
-    where TKey is class, TValue is class;
   private
     fDict: Dictionary<TKey, TValue>;
     method GetItem(const aKey: TKey): TValue;
@@ -54,6 +53,10 @@ type
     property Values: ISequence<TValue> read GetValues;
     property OnKeyNotify: TCollectionNotifyEvent<TKey>;
     property OnValueNotify: TCollectionNotifyEvent<TValue>;
+  end;
+
+  TObjectDictionary<TKey,TValue> = public class(TDictionary<TKey,TValue>)
+    where TKey is class, TValue is class;
   end;
 
 implementation


### PR DESCRIPTION
TDictionary should not force its items to be class instances, that's what TObjectDictionary is for