### PR TITLE
Do not force TKey and TValue to be a class on TObjectDictionary

### DIFF
--- a/Source/Collections.Dictionary.pas
+++ b/Source/Collections.Dictionary.pas
@@ -59,7 +59,6 @@ type
   TDictionaryOwnerships = set of (doOwnsKeys, doOwnsValues);
 
   TObjectDictionary<TKey,TValue> = public class(TDictionary<TKey,TValue>)
-    where TKey is class, TValue is class;
   private
     FOwnerships: TDictionaryOwnerships;
   public


### PR DESCRIPTION
This allows TObjectDictionary<string, Object> or TObjectDictionary<Object, Integer> for instance.