### PR TITLE
Set TEnumerable<T> to be a TDelphiObject 

### DIFF
--- a/Source/Collections.List.pas
+++ b/Source/Collections.List.pas
@@ -47,7 +47,7 @@ type
     end;
   end;
 
-  TEnumerable<T> = public abstract class(ISequence<T>)
+  TEnumerable<T> = public abstract class(TDelphiObject, ISequence<T>)
   private
     method ToArrayImpl(Count: Integer): TArray<T>;
   protected


### PR DESCRIPTION
Thus allowing users of DelphiRTL to override AfterConstruction on derived classes